### PR TITLE
set TLS1.3 to fix Bad Request error elpa.gnu.org emacs 26.1 in debian

### DIFF
--- a/init.el
+++ b/init.el
@@ -12,6 +12,7 @@
 (load "~/.emacs.d/messages")
 (setq load-prefer-newer t)
 (package-initialize)
+(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
 (load "~/.emacs.d/init-packages")
 
 (eval-when-compile


### PR DESCRIPTION
- https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341

  @ 00:25 hs